### PR TITLE
Add Namespace and update deno serve

### DIFF
--- a/examples/deno/deno.ts
+++ b/examples/deno/deno.ts
@@ -1,7 +1,6 @@
-import { serve } from "https://deno.land/std@0.140.0/http/server.ts";
 import { ServerSentEventGenerator } from "npm:@starfederation/datastar-sdk/web";
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   const url = new URL(req.url);
 
   if (url.pathname === "/") {

--- a/src/abstractServerSentEventGenerator.ts
+++ b/src/abstractServerSentEventGenerator.ts
@@ -174,7 +174,11 @@ export abstract class ServerSentEventGenerator<T = string[]> {
 
     // Validate namespace if provided
     const namespace = (renderOptions as Record<string, unknown>)[DatastarDatalineNamespace] as string | undefined;
-    if (namespace) {
+    const hasNamespace = DatastarDatalineNamespace in (renderOptions as Record<string, unknown>);
+    if (hasNamespace) {
+      if (typeof namespace !== "string" || namespace.trim() === "") {
+        throw new Error("Namespace, if provided, must be a non-empty string");
+      }
       this.validateNamespace(namespace);
     }
 

--- a/src/abstractServerSentEventGenerator.ts
+++ b/src/abstractServerSentEventGenerator.ts
@@ -6,15 +6,18 @@ import {
   PatchSignalsOptions,
   Jsonifiable,
   ElementPatchMode,
+  NamespaceType,
 } from "./types.ts";
 
 import {
   DatastarDatalineElements,
   DatastarDatalinePatchMode,
+  DatastarDatalineNamespace,
   DatastarDatalineSelector,
   DatastarDatalineSignals,
   DefaultSseRetryDurationMs,
   ElementPatchModes,
+  NamespaceTypes,
 } from "./consts.ts";
 
 /**
@@ -38,6 +41,16 @@ export abstract class ServerSentEventGenerator<T = string[]> {
     }
   }
 
+  /**
+   * Validates that the provided namespace is a valid NamespaceType.
+   * @param namespace - The namespace to validate
+   * @throws {Error} If the namespace is invalid
+   */
+  private validateNamespace(namespace: string): asserts namespace is NamespaceType {
+    if (!NamespaceTypes.includes(namespace as NamespaceType)) {
+      throw new Error(`Invalid namespace: "${namespace}". Valid namespaces are: ${NamespaceTypes.join(', ')}`);
+    }
+  }
 
   /**
    * Validates required parameters are not empty or undefined.
@@ -143,7 +156,7 @@ export abstract class ServerSentEventGenerator<T = string[]> {
    * ```
    *
    * @param elements - HTML string of elements to patch (must have IDs unless using selector).
-   * @param options - Patch options: selector, mode, useViewTransition, eventId, retryDuration.
+   * @param options - Patch options: selector, mode, namespace, useViewTransition, eventId, retryDuration.
    * @returns The SSE lines to send.
    */
   public patchElements(
@@ -157,6 +170,12 @@ export abstract class ServerSentEventGenerator<T = string[]> {
     const patchMode = (renderOptions as Record<string, unknown>)[DatastarDatalinePatchMode] as string;
     if (patchMode) {
       this.validateElementPatchMode(patchMode);
+    }
+
+    // Validate namespace if provided
+    const namespace = (renderOptions as Record<string, unknown>)[DatastarDatalineNamespace] as string | undefined;
+    if (namespace) {
+      this.validateNamespace(namespace);
     }
 
     // Check if we're in remove mode with a selector

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -13,6 +13,7 @@ export const DefaultPatchSignalsOnlyIfMissing = false;
 export const DatastarDatalineSelector = "selector"
 export const DatastarDatalinePatchMode = "mode"
 export const DatastarDatalineElements = "elements"
+export const DatastarDatalineNamespace = "namespace"
 export const DatastarDatalineUseViewTransition = "useViewTransition"
 export const DatastarDatalineSignals = "signals"
 export const DatastarDatalineOnlyIfMissing = "onlyIfMissing"
@@ -37,6 +38,11 @@ export const ElementPatchModes = [
     // Remove target element from DOM
     "remove",
 ] as const;
+
+export const NamespaceTypes = [
+    "svg",
+    "mathml"
+] as const
 
 // Default value for ElementPatchMode
 export const DefaultElementPatchMode = "outer";

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -41,8 +41,8 @@ export const ElementPatchModes = [
 
 export const NamespaceTypes = [
     "svg",
-    "mathml"
-] as const
+    "mathml",
+] as const;
 
 // Default value for ElementPatchMode
 export const DefaultElementPatchMode = "outer";

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,25 +4,28 @@ import {
   DatastarDatalineOnlyIfMissing,
   DatastarDatalineSelector,
   DatastarDatalineSignals,
+  DatastarDatalineNamespace,
   DatastarDatalineUseViewTransition,
   DefaultElementPatchMode,
   DefaultElementsUseViewTransitions,
   DefaultPatchSignalsOnlyIfMissing,
   EventTypes,
   ElementPatchModes,
+  NamespaceTypes,
 } from "./consts.ts";
 
 // Simple Jsonifiable type definition to replace npm:type-fest dependency
-export type Jsonifiable = 
-  | string 
-  | number 
-  | boolean 
-  | null 
+export type Jsonifiable =
+  | string
+  | number
+  | boolean
+  | null
   | undefined
-  | Jsonifiable[] 
+  | Jsonifiable[]
   | { [key: string]: Jsonifiable };
 
 export type ElementPatchMode = typeof ElementPatchModes[number];
+export type NamespaceType = typeof NamespaceTypes[number];
 export type EventType = typeof EventTypes[number];
 
 export type StreamOptions = Partial<{
@@ -44,6 +47,7 @@ export interface ElementOptions extends DatastarEventOptions {
 export interface PatchElementsOptions extends ElementOptions {
   [DatastarDatalinePatchMode]?: ElementPatchMode;
   [DatastarDatalineSelector]?: string;
+  [DatastarDatalineNamespace]?: NamespaceType;
 }
 
 export interface patchElementsEvent {

--- a/test/bun.ts
+++ b/test/bun.ts
@@ -75,11 +75,12 @@ function testEvents(stream, events) {
     const { type, ...e } = event;
     switch (type) {
       case "patchElements": {
-        const { elements, mode, selector, useViewTransition, ...options } = e;
+        const { elements, mode, selector, useViewTransition, namespace, ...options } = e;
         const patchOptions = { ...options };
         if (mode && mode !== "outer") patchOptions.mode = mode;
         if (selector) patchOptions.selector = selector;
         if (useViewTransition !== undefined) patchOptions.useViewTransition = useViewTransition;
+        if (namespace) patchOptions.namespace = namespace;
         stream.patchElements(elements || "", patchOptions);
         break;
       }

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,9 +1,8 @@
-import { serve } from "https://deno.land/std@0.140.0/http/server.ts";
 import { ServerSentEventGenerator } from "../npm/esm/web/serverSentEventGenerator.js";
 import type { Jsonifiable } from "../src/types.ts";
 
 // This server is used for testing the web standard based sdk
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   const url = new URL(req.url);
 
   if (url.pathname === "/") {

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -77,11 +77,12 @@ function testEvents(
     const { type, ...e } = event;
     switch (type) {
       case "patchElements": {
-        const { elements, mode, selector, useViewTransition, ...options } = e;
+        const { elements, mode, selector, useViewTransition, namespace, ...options } = e;
         const patchOptions: Record<string, unknown> = { ...options };
         if (mode && mode !== "outer") patchOptions.mode = mode;
         if (selector) patchOptions.selector = selector;
         if (useViewTransition !== undefined) patchOptions.useViewTransition = useViewTransition;
+        if (namespace) patchOptions.namespace = namespace;
         stream.patchElements((elements as string) || "", patchOptions);
         break;
       }

--- a/test/node.ts
+++ b/test/node.ts
@@ -82,11 +82,12 @@ function testEvents(
     const { type, ...e } = event;
     switch (type) {
       case "patchElements": {
-        const { elements, mode, selector, useViewTransition, ...options } = e;
+        const { elements, mode, selector, useViewTransition, namespace, ...options } = e;
         const patchOptions: Record<string, unknown> = { ...options };
         if (mode && mode !== "outer") patchOptions.mode = mode;
         if (selector) patchOptions.selector = selector;
         if (useViewTransition !== undefined) patchOptions.useViewTransition = useViewTransition;
+        if (namespace) patchOptions.namespace = namespace;
         stream.patchElements((elements as string) || "", patchOptions);
         break;
       }


### PR DESCRIPTION
Fixes #12 

Adds a namespace type. Its entirely possible this is not done correctly - i dont quite understand how it all works. It is a good start though.

Also updates the archaic version of deno serve with the latest api.  

I did run 
```
deno run -A build.ts 
./test/run-all.sh
```
and it all passed.

But, as was noted in #12, there's no tests for namespace... 