### PR TITLE
Release prep: v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Datastar TypeScript SDK 
 
-[![Version](https://img.shields.io/badge/version-1.0.0–RC.4-orange)](https://github.com/starfederation/datastar-typescript/releases) [![npm](https://img.shields.io/npm/v/@starfederation/datastar-sdk?logo=npm&labelColor=CB3837&color=black)](https://www.npmjs.com/package/@starfederation/datastar-sdk) 
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/starfederation/datastar-typescript/releases) [![npm](https://img.shields.io/npm/v/@starfederation/datastar-sdk?logo=npm&labelColor=CB3837&color=black)](https://www.npmjs.com/package/@starfederation/datastar-sdk) 
 
 [![Node.js](https://img.shields.io/badge/run_time-node_js-2a682d?logo=nodedotjs&labelColor=black)](https://nodejs.org/) [![Deno](https://img.shields.io/badge/run_time-deno-6affaf?logo=deno&labelColor=black)](https://deno.land/) [![Bun](https://img.shields.io/badge/run_time-bun-f672b6?logo=bun&labelColor=black)](https://bun.sh/)
 

--- a/examples/bun/bun.ts
+++ b/examples/bun/bun.ts
@@ -5,7 +5,7 @@ const server = Bun.serve({
   routes: {
     "/": () => {
       return new Response(
-        `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+        `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
         {
           headers: { "Content-Type": "text/html" },
         },

--- a/examples/deno/deno.ts
+++ b/examples/deno/deno.ts
@@ -5,7 +5,7 @@ Deno.serve(async (req: Request) => {
 
   if (url.pathname === "/") {
     return new Response(
-      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
       {
         headers: { "Content-Type": "text/html" },
       },

--- a/examples/node/node.js
+++ b/examples/node/node.js
@@ -9,7 +9,7 @@ const server = createServer(async (req, res) => {
     const headers = new Headers({ "Content-Type": "text/html" });
     res.setHeaders(headers);
     res.end(
-      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
     );
   } else if (req.url?.includes("/merge")) {
     const reader = await ServerSentEventGenerator.readSignals(req);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@starfederation/datastar-sdk",
-  "version": "1.0.0-RC.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@starfederation/datastar-sdk",
-      "version": "1.0.0-RC.4",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starfederation/datastar-sdk",
-  "version": "1.0.0-RC.4",
+  "version": "1.0.0",
   "description": "TypeScript SDK for Datastar",
   "scripts": {
     "build": "deno run -A build.ts",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,6 @@
 export const DATASTAR = "datastar" as const;
 export const DATASTAR_REQUEST = "Datastar-Request";
-export const VERSION = "1.0.0-RC.4";
+export const VERSION = "1.0.0";
 
 // The default duration for retrying SSE on connection reset. This is part of the underlying retry mechanism of SSE.
 export const DefaultSseRetryDurationMs = 1000;

--- a/src/node/serverSentEventGenerator.ts
+++ b/src/node/serverSentEventGenerator.ts
@@ -114,7 +114,7 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
     | { success: true; signals: Record<string, Jsonifiable> }
     | { success: false; error: string }
   > {
-    if (["GET", "DELETE"].includes(request.method)) {
+    if (request.method && ["GET", "DELETE"].includes(request.method)) {
       const url = new URL(
         `http://${process.env.HOST ?? "localhost"}${request.url}`,
       );

--- a/test/bun.ts
+++ b/test/bun.ts
@@ -8,7 +8,7 @@ const server = Bun.serve({
 
     if (url.pathname === "/") {
       return new Response(
-        `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+        `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
         {
           headers: { "Content-Type": "text/html" },
         },

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -7,7 +7,7 @@ Deno.serve(async (req: Request) => {
 
   if (url.pathname === "/") {
     return new Response(
-      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
       {
         headers: { "Content-Type": "text/html" },
       },

--- a/test/node.ts
+++ b/test/node.ts
@@ -10,7 +10,7 @@ const server = createServer(async (req, res) => {
   if (req.url === "/") {
     res.setHeader("Content-Type", "text/html");
     res.end(
-      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
+      `<html><head><script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js"></script></head><body><div id="toMerge" data-signals:foo="'World'" data-init="@get('/merge')">Hello</div></body></html>`,
     );
   } else if (req.url?.includes("/merge")) {
     const reader = await ServerSentEventGenerator.readSignals(req);


### PR DESCRIPTION
## Summary
- Hotfix the TS2345 build failure introduced by #14 (Node's `IncomingMessage.method` is `string | undefined`, so `["GET", "DELETE"].includes(request.method)` doesn't type-check).
- Bump SDK version `1.0.0-RC.4` → `1.0.0` (package.json, package-lock.json, `src/consts.ts` VERSION, README badge).
- Update datastar CDN refs in `examples/` and `test/` from `@1.0.0-RC.7` → `@1.0.1` (current stable).

## Test plan
- [x] `deno run -A build.ts` passes type-check
- [x] `bash ./test/run-all.sh` — all cross-SDK tests pass on node/bun/deno against upstream `develop`

## Follow-ups (not in this PR)
- No DELETE-specific regression coverage in `test/{node,bun,deno}.ts`; upstream Go test suite doesn't exercise it either. Worth adding if we want belt-and-suspenders on the new path.